### PR TITLE
blocks.js hotfix

### DIFF
--- a/lib/modules/blocks.js
+++ b/lib/modules/blocks.js
@@ -4,7 +4,7 @@ const Vec3 = require('vec3');
 module.exports.placeBlock = async (bot) => {
     let availableItems = bot.inventory.items()
         .map((i)=>i.type)
-        .filter(v => bot.afk.config.placing.includes(v));
+        .filter(v => v == bot.afk.config.placing);
     let block = utils.randomElement(availableItems);
     try{
         await bot.equip(block, 'hand');


### PR DESCRIPTION
Fixes [this issue](https://github.com/etiaro/mineflayer-antiafk/issues/3#issue-957181656)

Basically, in the default `antiafk.js` where the `setOptions` function is created, when `placing` is false, it defaults into an array of `Integers`.
Then in your `blocks.js` you are trying to access the function `includes` on an integer, that doesn't exist. includes only works on string arrays!
Changing it to loose equality is not the best but it does the job for now. And the only thing I can think of, but another solution would be turning the array into strings (which I think will break the code).

