### PR TITLE
bump deps to improve deduping

### DIFF
--- a/lib/antiafk.js
+++ b/lib/antiafk.js
@@ -1,6 +1,6 @@
 const utils = require('./utils');
 const modules = require('./modules');
-const autoeat = require("mineflayer-auto-eat")
+const autoeat = require("mineflayer-auto-eat").plugin;
 
 async function rotate(bot){
     let yaw = 2*Math.random()*Math.PI - (0.5*Math.PI);

--- a/lib/antiafk.js
+++ b/lib/antiafk.js
@@ -138,4 +138,4 @@ function inject (bot) {
 }
   
   
-  module.exports = inject;
+module.exports = inject;

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "mineflayer-auto-eat": "^2.0.0",
+    "mineflayer-auto-eat": "^3.3.6",
     "vec3": "^0.1.7"
   },
   "devDependencies": {
-    "mineflayer": "^3.6.0"
+    "mineflayer": "^4.8.1"
   }
 }


### PR DESCRIPTION
Some of my projects are doubling up on their minecraft-data library due to this library using an older version. This PR should fix that by updating the dependancies' versions.